### PR TITLE
When running under JRuby (1.8 mode), exitstatus is not initialized to 0

### DIFF
--- a/lib/subexec.rb
+++ b/lib/subexec.rb
@@ -45,6 +45,7 @@ class Subexec
     self.command  = command
     self.timeout  = options[:timeout] || -1 # default is to never timeout
     self.lang     = options[:lang] || "C"
+    self.exitstatus = 0
   end
   
   def run!


### PR DESCRIPTION
When running under JRuby (1.8 mode), exitstatus is not initialized to 0, and then CarrierWave thinks the exec failed.
