### PR TITLE
Carrierwave under JRuby in 1.8 mode

### DIFF
--- a/lib/subexec.rb
+++ b/lib/subexec.rb
@@ -45,6 +45,7 @@ class Subexec
     self.command  = command
     self.timeout  = options[:timeout] || -1 # default is to never timeout
     self.lang     = options[:lang] || "C"
+    self.exitstatus = 0
   end
   
   def run!


### PR DESCRIPTION
Uploads were failing due to an initialized existstatus. This fixes it. 
