### PR TITLE
fix for Windows execution command

### DIFF
--- a/lib/subexec.rb
+++ b/lib/subexec.rb
@@ -115,7 +115,7 @@ class Subexec
   
     def exec
       if !(RUBY_PLATFORM =~ /win32|mswin|mingw/).nil?
-        self.output = `set LANG=#{lang} && #{command} 2>&1`
+        self.output = `set LANG=#{lang} && #{command} 2>NUL >NUL`
       else
         self.output = `export LANG=#{lang} && #{command} 2>&1`
       end


### PR DESCRIPTION
Hi!
 As commented in [this link](https://github.com/nulayer/subexec/commit/7b22891b55d591e2841586797d64d599ea7354a3) I make a pull request.
Maybe this will close the issue #4. We've the same problem in one of our apps. I've tested it and it works now.
Thanks!
 Cristian
@gissues:{"order":80,"status":"backlog"}
