### PR TITLE
make subexec work on the Sun Solaris OS

### DIFF
--- a/lib/subexec.rb
+++ b/lib/subexec.rb
@@ -117,7 +117,7 @@ class Subexec
       if !(RUBY_PLATFORM =~ /win32|mswin|mingw/).nil?
         self.output = `set LANG=#{lang} && #{command} 2>&1`
       else
-        self.output = `export LANG=#{lang} && #{command} 2>&1`
+        self.output = `LANG=#{lang} && export $LANG && #{command} 2>&1`
       end
       self.exitstatus = $?.exitstatus
     end


### PR DESCRIPTION
Hi,

I recently updated the dependencies for an older app, including subexec, and recognized that file uploads stopped working. Digging deeper, I identified the way subexec shells out with a LANG environment variable set as the problem. Example:

irb(main):010:0> f = File.new('iNd88.jpg')
=> #File:iNd88.jpg
irb(main):011:0> MiniMagick::Image.open f.path
sh: LANG=C: is not an identifier
MiniMagick::Error: Command ("identify -ping /tmp/mini_magick20120214-16088-85xa95-0.jpg") failed: {:output=>"", :status_code=>1}

This is easily resolved by the attached patch. It should be compatible even with very restrictive shells, like the default Solaris /bin/sh shell.
