### PR TITLE
JRuby 1.9 compatibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,44 +2,31 @@ PATH
   remote: .
   specs:
     subexec (0.2.1)
-      posix-spawn
+      posix-spawn (~> 0.3)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    archive-tar-minitar (0.5.2)
     columnize (0.3.4)
     diff-lcs (1.1.3)
     linecache (0.46)
       rbx-require-relative (> 0.0.4)
-    linecache19 (0.5.12)
-      ruby_core_source (>= 0.1.4)
     posix-spawn (0.3.6)
     rake (0.9.2.2)
     rbx-require-relative (0.0.5)
-    rspec (2.7.0)
-      rspec-core (~> 2.7.0)
-      rspec-expectations (~> 2.7.0)
-      rspec-mocks (~> 2.7.0)
-    rspec-core (2.7.1)
-    rspec-expectations (2.7.0)
+    rspec (2.8.0)
+      rspec-core (~> 2.8.0)
+      rspec-expectations (~> 2.8.0)
+      rspec-mocks (~> 2.8.0)
+    rspec-core (2.8.0)
+    rspec-expectations (2.8.0)
       diff-lcs (~> 1.1.2)
-    rspec-mocks (2.7.0)
+    rspec-mocks (2.8.0)
     ruby-debug (0.10.4)
       columnize (>= 0.1)
       ruby-debug-base (~> 0.10.4.0)
     ruby-debug-base (0.10.4)
       linecache (>= 0.3)
-    ruby-debug-base19 (0.11.25)
-      columnize (>= 0.3.1)
-      linecache19 (>= 0.5.11)
-      ruby_core_source (>= 0.1.4)
-    ruby-debug19 (0.11.6)
-      columnize (>= 0.3.1)
-      linecache19 (>= 0.5.11)
-      ruby-debug-base19 (>= 0.11.19)
-    ruby_core_source (0.1.5)
-      archive-tar-minitar (>= 0.5.2)
 
 PLATFORMS
   java
@@ -47,7 +34,6 @@ PLATFORMS
 
 DEPENDENCIES
   rake
-  rspec (~> 2.7.0)
+  rspec (~> 2.8.0)
   ruby-debug
-  ruby-debug19
   subexec!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,20 @@
 PATH
   remote: .
   specs:
-    subexec (0.2.0)
+    subexec (0.2.1)
+      posix-spawn
 
 GEM
   remote: http://rubygems.org/
   specs:
+    archive-tar-minitar (0.5.2)
     columnize (0.3.4)
     diff-lcs (1.1.3)
     linecache (0.46)
       rbx-require-relative (> 0.0.4)
+    linecache19 (0.5.12)
+      ruby_core_source (>= 0.1.4)
+    posix-spawn (0.3.6)
     rake (0.9.2.2)
     rbx-require-relative (0.0.5)
     rspec (2.7.0)
@@ -25,12 +30,24 @@ GEM
       ruby-debug-base (~> 0.10.4.0)
     ruby-debug-base (0.10.4)
       linecache (>= 0.3)
+    ruby-debug-base19 (0.11.25)
+      columnize (>= 0.3.1)
+      linecache19 (>= 0.5.11)
+      ruby_core_source (>= 0.1.4)
+    ruby-debug19 (0.11.6)
+      columnize (>= 0.3.1)
+      linecache19 (>= 0.5.11)
+      ruby-debug-base19 (>= 0.11.19)
+    ruby_core_source (0.1.5)
+      archive-tar-minitar (>= 0.5.2)
 
 PLATFORMS
+  java
   ruby
 
 DEPENDENCIES
   rake
   rspec (~> 2.7.0)
   ruby-debug
+  ruby-debug19
   subexec!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,10 +7,13 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
+    archive-tar-minitar (0.5.2)
     columnize (0.3.4)
     diff-lcs (1.1.3)
     linecache (0.46)
       rbx-require-relative (> 0.0.4)
+    linecache19 (0.5.12)
+      ruby_core_source (>= 0.1.4)
     posix-spawn (0.3.6)
     rake (0.9.2.2)
     rbx-require-relative (0.0.5)
@@ -27,6 +30,16 @@ GEM
       ruby-debug-base (~> 0.10.4.0)
     ruby-debug-base (0.10.4)
       linecache (>= 0.3)
+    ruby-debug-base19 (0.11.25)
+      columnize (>= 0.3.1)
+      linecache19 (>= 0.5.11)
+      ruby_core_source (>= 0.1.4)
+    ruby-debug19 (0.11.6)
+      columnize (>= 0.3.1)
+      linecache19 (>= 0.5.11)
+      ruby-debug-base19 (>= 0.11.19)
+    ruby_core_source (0.1.5)
+      archive-tar-minitar (>= 0.5.2)
 
 PLATFORMS
   java
@@ -36,4 +49,5 @@ DEPENDENCIES
   rake
   rspec (~> 2.8.0)
   ruby-debug
+  ruby-debug19
   subexec!

--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ puts sub.output     # returns: hello
 puts sub.exitstatus # returns: 0
 
 sub = Subexec.run "echo 'hello' && sleep 3", :timeout => 1
-puts sub.output     # returns: 
+puts sub.output     # returns:
 puts sub.exitstatus # returns:`
 ```
 
 ## Limitations
 
 Only Ruby 1.9 can spawn non-blocking subprocesses, via Process.spawn.
-So Ruby 1.8 support is sheerly for backwards compatibility. 
+So Ruby 1.8 support is sheerly for backwards compatibility.
 
 ## Windows Support
 

--- a/lib/subexec.rb
+++ b/lib/subexec.rb
@@ -25,10 +25,10 @@
 # puts sub.output     # returns:
 # puts sub.exitstatus # returns:
 
+require 'subexec/version'
 require 'posix-spawn'
 
 class Subexec
-  VERSION = '0.2.1'
 
   attr_accessor :pid,
                 :command,

--- a/lib/subexec.rb
+++ b/lib/subexec.rb
@@ -25,6 +25,8 @@
 # puts sub.output     # returns:
 # puts sub.exitstatus # returns:
 
+require 'posix-spawn'
+
 class Subexec
   VERSION = '0.2.1'
 
@@ -66,9 +68,9 @@ class Subexec
       # Ideally, the data would be piped through to both descriptors
       r, w = IO.pipe
       if !log_file.nil?
-        self.pid = Process.spawn({'LANG' => self.lang}, command, [:out, :err] => [log_file, 'a'])
+        self.pid = POSIX::Spawn::spawn({'LANG' => self.lang}, command, [:out, :err] => [log_file, 'a'])
       else
-        self.pid = Process.spawn({'LANG' => self.lang}, command, STDERR=>w, STDOUT=>w)
+        self.pid = POSIX::Spawn::spawn({'LANG' => self.lang}, command, STDERR=>w, STDOUT=>w)
       end
       w.close
 

--- a/lib/subexec.rb
+++ b/lib/subexec.rb
@@ -1,28 +1,28 @@
 # # Subexec
 # * by Peter Kieltyka
 # * http://github/nulayer/subexec
-# 
+#
 # ## Description
-# 
+#
 # Subexec is a simple library that spawns an external command with
 # an optional timeout parameter. It relies on Ruby 1.9's Process.spawn
 # method. Also, it works with synchronous and asynchronous code.
-# 
+#
 # Useful for libraries that are Ruby wrappers for CLI's. For example,
 # resizing images with ImageMagick's mogrify command sometimes stalls
 # and never returns control back to the original process. Subexec
 # executes mogrify and preempts if it gets lost.
-# 
+#
 # ## Usage
-# 
+#
 # # Print hello
 # sub = Subexec.run "echo 'hello' && sleep 3", :timeout => 5
 # puts sub.output     # returns: hello
 # puts sub.exitstatus # returns: 0
-# 
+#
 # # Timeout process after a second
 # sub = Subexec.run "echo 'hello' && sleep 3", :timeout => 1
-# puts sub.output     # returns: 
+# puts sub.output     # returns:
 # puts sub.exitstatus # returns:
 
 class Subexec
@@ -41,7 +41,7 @@ class Subexec
     sub.run!
     sub
   end
-  
+
   def initialize(command, options={})
     self.command    = command
     self.lang       = options[:lang]      || "C"
@@ -49,7 +49,7 @@ class Subexec
     self.log_file   = options[:log_file]
     self.exitstatus = 0
   end
-  
+
   def run!
     if RUBY_VERSION >= '1.9'
       spawn
@@ -60,18 +60,18 @@ class Subexec
 
 
   private
-  
+
     def spawn
       # TODO: weak implementation for log_file support.
       # Ideally, the data would be piped through to both descriptors
-      r, w = IO.pipe      
+      r, w = IO.pipe
       if !log_file.nil?
         self.pid = Process.spawn({'LANG' => self.lang}, command, [:out, :err] => [log_file, 'a'])
       else
         self.pid = Process.spawn({'LANG' => self.lang}, command, STDERR=>w, STDOUT=>w)
       end
       w.close
-      
+
       @timer = Time.now + timeout
       timed_out = false
 
@@ -109,10 +109,10 @@ class Subexec
         self.output = r.readlines.join("")
       end
       r.close
-      
+
       self
     end
-  
+
     def exec
       if !(RUBY_PLATFORM =~ /win32|mswin|mingw/).nil?
         self.output = `set LANG=#{lang} && #{command} 2>&1`

--- a/lib/subexec/version.rb
+++ b/lib/subexec/version.rb
@@ -1,0 +1,3 @@
+class Subexec
+  VERSION = '0.2.1'
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,7 +20,7 @@ require 'subexec'
 require 'rspec'
 
 RSpec.configure do |config|
-  config.mock_with :rspec  
+  config.mock_with :rspec
 end
 
 TEST_PROG = File.join(File.dirname(__FILE__), 'helloworld.sh')

--- a/spec/subexec_spec.rb
+++ b/spec/subexec_spec.rb
@@ -2,13 +2,13 @@ require 'spec_helper'
 
 describe Subexec do
   context 'Subexec class' do
-    
+
     it 'run helloworld script' do
       sub = Subexec.run "#{TEST_PROG} 1"
       sub.output.should == "Hello\nWorld\n"
       sub.exitstatus.should == 0
     end
-    
+
     it 'timeout helloworld script' do
       sub = Subexec.run "#{TEST_PROG} 2", :timeout => 1
       if RUBY_VERSION >= '1.9'
@@ -19,20 +19,20 @@ describe Subexec do
         sub.exitstatus.should == 0
       end
     end
-    
+
     it 'set LANG env variable on request' do
       original_lang = `echo $LANG`
-    
+
       sub = Subexec.run "echo $LANG", :lang => "fr_FR.UTF-8"
       sub.output.should == "fr_FR.UTF-8\n"
       sub = Subexec.run "echo $LANG", :lang => "C"
       sub.output.should == "C\n"
       sub = Subexec.run "echo $LANG", :lang => "en_US.UTF-8"
       sub.output.should == "en_US.UTF-8\n"
-      
+
       `echo $LANG`.should == original_lang
     end
-    
+
     it 'default LANG to C' do
       sub = Subexec.run "echo $LANG"
       sub.output.should == "C\n"
@@ -42,16 +42,16 @@ describe Subexec do
       if RUBY_VERSION >= '1.9'
         require 'tempfile'
         log_file = Tempfile.new('foo')
-      
+
         sub = Subexec.run "#{TEST_PROG} 1", :log_file => log_file.path
         sub.output.should == ''
         sub.exitstatus.should == 0
-      
+
         log_file.read.should == "Hello\nWorld\n"
         log_file.close
         log_file.unlink
       end
     end
-    
-  end  
+
+  end
 end

--- a/subexec.gemspec
+++ b/subexec.gemspec
@@ -1,5 +1,6 @@
 $:.push File.expand_path('../lib', __FILE__)
-require 'subexec'
+
+require 'subexec/version'
 
 Gem::Specification.new do |s|
   s.name        = 'subexec'
@@ -15,8 +16,8 @@ Gem::Specification.new do |s|
   s.files        = Dir['README.md', 'lib/**/*']
   s.require_path = 'lib'
 
-  s.add_dependency('posix-spawn')
+  s.add_dependency('posix-spawn', ['~> 0.3'])
 
   s.add_development_dependency('rake')
-  s.add_development_dependency('rspec', ['~> 2.7.0'])
+  s.add_development_dependency('rspec', ['~> 2.8.0'])
 end

--- a/subexec.gemspec
+++ b/subexec.gemspec
@@ -15,6 +15,8 @@ Gem::Specification.new do |s|
   s.files        = Dir['README.md', 'lib/**/*']
   s.require_path = 'lib'
 
+  s.add_dependency('posix-spawn')
+
   s.add_development_dependency('rake')
   s.add_development_dependency('rspec', ['~> 2.7.0'])
 end

--- a/subexec.gemspec
+++ b/subexec.gemspec
@@ -7,14 +7,14 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.summary     = "Subexec spawns a subprocess with an optional timeout"
   s.description = s.summary
-  
+
   s.authors     = ["Peter Kieltyka"]
   s.email       = ["peter@nulayer.com"]
   s.homepage    = "http://github.com/nulayer/subexec"
 
   s.files        = Dir['README.md', 'lib/**/*']
   s.require_path = 'lib'
-  
+
   s.add_development_dependency('rake')
   s.add_development_dependency('rspec', ['~> 2.7.0'])
 end


### PR DESCRIPTION
Tests are not passing on JRuby

jruby --1.9 -S bundle exec rake

On JRuby 1.9 there is some problem with:
pid = spawn("ls"); p pid; Process.waitpid(pid)
Errno::ECHILD: No child processes - No child processes

jruby --1.9 -S irb
require 'subexec'
Subexec.run('ls')
...
LocalJumpError: break from proc-closure

Thanks to posix-spawn it's getting better!
