### PR TITLE
Use POSIX::Spawn if available to speed up forking

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,5 @@ gemspec
 group :development, :test do
   gem 'pry'
   gem 'pry-nav'
+  gem 'posix-spawn'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,7 @@ GEM
     coderay (1.0.6)
     diff-lcs (1.1.3)
     method_source (0.7.1)
+    posix-spawn (0.3.6)
     pry (0.9.8.4)
       coderay (~> 1.0.5)
       method_source (~> 0.7.1)
@@ -37,6 +38,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  posix-spawn
   pry
   pry-nav
   rake

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,7 +38,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  posix-spawn (~> 0.3.8)
+  posix-spawn
   pry
   pry-nav
   rake

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Useful for libraries that are Ruby wrappers for CLI's. For example,
 resizing images with ImageMagick's mogrify command sometimes stalls
 and never returns control back to the original process. Enter Subexec.
 
+If the posix-spawn gem is available it will be used for spawning
+which can provide a significant performance improvement in applications
+that have very large heaps.
+
 Tested with MRI 1.9.3, 1.9.2, 1.8.7
 
 Note: Process.spawn seems to be broken with JRuby 1.7.0.dev (as of

--- a/lib/subexec.rb
+++ b/lib/subexec.rb
@@ -81,7 +81,11 @@ class Subexec
 
       log_to_file = !log_file.nil?
       log_opts = log_to_file ? {[:out, :err] => [log_file, 'a']} : {STDERR=>w, STDOUT=>w}
-      self.pid = Process.spawn({'LANG' => self.lang}, command, log_opts)
+      if posix_spawn_available?
+        self.pid = POSIX::Spawn.spawn({'LANG' => self.lang}, command, log_opts)
+      else
+        self.pid = Process.spawn({'LANG' => self.lang}, command, log_opts)
+      end
       w.close
 
       @timer = Time.now + timeout

--- a/spec/subexec_spec.rb
+++ b/spec/subexec_spec.rb
@@ -63,14 +63,14 @@ describe Subexec do
 
     it 'should use POSIX::Spawn if available' do
       sub = Subexec.run "#{TEST_PROG} 1"
-      sub.stub(:posix_spawn_available => true)
+      sub.stub(:posix_spawn_available? => true)
       sub.output.should == "Hello\nWorld\n"
       sub.exitstatus.should == 0
     end
 
     it 'should use built in spawn if POSIX::Spawn is not available' do
       sub = Subexec.run "#{TEST_PROG} 1"
-      sub.stub(:posix_spawn_available => true)
+      sub.stub(:posix_spawn_available? => false)
       sub.output.should == "Hello\nWorld\n"
       sub.exitstatus.should == 0
     end

--- a/spec/subexec_spec.rb
+++ b/spec/subexec_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 
 describe Subexec do
   context 'Subexec class' do
-    
     it 'run helloworld script' do
       sub = Subexec.run "#{TEST_PROG} 1"
       sub.output.should == "Hello\nWorld\n"
@@ -52,6 +51,5 @@ describe Subexec do
         log_file.unlink
       end
     end
-    
-  end  
+  end
 end


### PR DESCRIPTION
This pull request adds support to use the posix-spawn gem if it is available (https://github.com/rtomayko/posix-spawn). This can greatly speed up forking processes when the application has a large heap by preventing the entire heap from being copied to the new process. This is most noticeable on Linux and can be quite pronounced when the heap is from a large web application.
@gissues:{"order":20,"status":"backlog"}
