### PR TITLE
Prevent hanging when the spawned process fills the pipe buffer and no timeout is set.

### DIFF
--- a/lib/subexec.rb
+++ b/lib/subexec.rb
@@ -1,28 +1,28 @@
 # # Subexec
 # * by Peter Kieltyka
 # * http://github/nulayer/subexec
-# 
+#
 # ## Description
-# 
+#
 # Subexec is a simple library that spawns an external command with
 # an optional timeout parameter. It relies on Ruby 1.9's Process.spawn
 # method. Also, it works with synchronous and asynchronous code.
-# 
+#
 # Useful for libraries that are Ruby wrappers for CLI's. For example,
 # resizing images with ImageMagick's mogrify command sometimes stalls
 # and never returns control back to the original process. Subexec
 # executes mogrify and preempts if it gets lost.
-# 
+#
 # ## Usage
-# 
+#
 # # Print hello
 # sub = Subexec.run "echo 'hello' && sleep 3", :timeout => 5
 # puts sub.output     # returns: hello
 # puts sub.exitstatus # returns: 0
-# 
+#
 # # Timeout process after a second
 # sub = Subexec.run "echo 'hello' && sleep 3", :timeout => 1
-# puts sub.output     # returns: 
+# puts sub.output     # returns:
 # puts sub.exitstatus # returns:
 
 class Subexec
@@ -41,7 +41,7 @@ class Subexec
     sub.run!
     sub
   end
-  
+
   def initialize(command, options={})
     self.command    = command
     self.lang       = options[:lang]      || "C"
@@ -49,7 +49,7 @@ class Subexec
     self.log_file   = options[:log_file]
     self.exitstatus = 0
   end
-  
+
   def run!
     if RUBY_VERSION >= '1.9' && RUBY_ENGINE != 'jruby'
       spawn
@@ -60,43 +60,43 @@ class Subexec
 
 
   private
-  
+
     def spawn
       # TODO: weak implementation for log_file support.
       # Ideally, the data would be piped through to both descriptors
-      r, w = IO.pipe      
-      if !log_file.nil?
-        self.pid = Process.spawn({'LANG' => self.lang}, command, [:out, :err] => [log_file, 'a'])
-      else
-        self.pid = Process.spawn({'LANG' => self.lang}, command, STDERR=>w, STDOUT=>w)
-      end
+      r, w = IO.pipe
+
+      log_to_file = !log_file.nil?
+      log_opts = log_to_file ? {[:out, :err] => [log_file, 'a']} : {STDERR=>w, STDOUT=>w}
+      self.pid = Process.spawn({'LANG' => self.lang}, command, log_opts)
       w.close
-      
+
       @timer = Time.now + timeout
       timed_out = false
 
-      waitpid = Proc.new do
-        begin
-          flags = (timeout > 0 ? Process::WUNTRACED|Process::WNOHANG : 0)
-          Process.waitpid(pid, flags)
+      self.output = ''
+
+      append_to_output = Proc.new do
+        self.output << r.readlines.join('')  unless log_to_file
+      end
+
+      loop do
+        ret = begin
+          Process.waitpid(pid, Process::WUNTRACED|Process::WNOHANG)
         rescue Errno::ECHILD
           break
         end
-      end
 
-      if timeout > 0
-        loop do
-          ret = waitpid.call
+        break if ret == pid
 
-          break if ret == pid
-          sleep 0.01
-          if Time.now > @timer
-            timed_out = true
-            break
-          end
+        append_to_output.call
+
+        if timeout > 0 && Time.now > @timer
+          timed_out = true
+          break
         end
-      else
-        waitpid.call
+
+        sleep 0.01
       end
 
       if timed_out
@@ -106,13 +106,13 @@ class Subexec
       else
         # The subprocess exited on its own
         self.exitstatus = $?.exitstatus
-        self.output = r.readlines.join("")
+        append_to_output.call
       end
       r.close
-      
+
       self
     end
-  
+
     def exec
       if !(RUBY_PLATFORM =~ /win32|mswin|mingw/).nil?
         self.output = `set LANG=#{lang} && #{command} 2>&1`

--- a/spec/subexec_spec.rb
+++ b/spec/subexec_spec.rb
@@ -1,14 +1,15 @@
 require 'spec_helper'
+require 'timeout'
 
 describe Subexec do
   context 'Subexec class' do
-    
+
     it 'run helloworld script' do
       sub = Subexec.run "#{TEST_PROG} 1"
       sub.output.should == "Hello\nWorld\n"
       sub.exitstatus.should == 0
     end
-    
+
     it 'timeout helloworld script' do
       sub = Subexec.run "#{TEST_PROG} 2", :timeout => 1
       if RUBY_VERSION >= '1.9'
@@ -19,20 +20,20 @@ describe Subexec do
         sub.exitstatus.should == 0
       end
     end
-    
+
     it 'set LANG env variable on request' do
       original_lang = `echo $LANG`
-    
+
       sub = Subexec.run "echo $LANG", :lang => "fr_FR.UTF-8"
       sub.output.should == "fr_FR.UTF-8\n"
       sub = Subexec.run "echo $LANG", :lang => "C"
       sub.output.should == "C\n"
       sub = Subexec.run "echo $LANG", :lang => "en_US.UTF-8"
       sub.output.should == "en_US.UTF-8\n"
-      
+
       `echo $LANG`.should == original_lang
     end
-    
+
     it 'default LANG to C' do
       sub = Subexec.run "echo $LANG"
       sub.output.should == "C\n"
@@ -42,16 +43,23 @@ describe Subexec do
       if RUBY_VERSION >= '1.9'
         require 'tempfile'
         log_file = Tempfile.new('foo')
-      
+
         sub = Subexec.run "#{TEST_PROG} 1", :log_file => log_file.path
         sub.output.should == ''
         sub.exitstatus.should == 0
-      
+
         log_file.read.should == "Hello\nWorld\n"
         log_file.close
         log_file.unlink
       end
     end
-    
-  end  
+
+    it 'can handle commands with lengthy outputs and no timeout set' do
+      # See this issue:
+      # http://stackoverflow.com/questions/13829830/ruby-process-spawn-stdout-pipe-buffer-size-limit
+      cmd = "for i in {1..6600}; do echo '123456789'; done"
+      lambda { Timeout::timeout(5) { Subexec.run cmd } }.should_not raise_exception
+    end
+
+  end
 end


### PR DESCRIPTION
I found that commands run w/o timeouts would hang if they produced enough output to fill the pipe buffer. The ruby pipe object fills up then stops reading until it gets read from, the spawned process never finishes while it waits for the pipe to accept more input, and so `Process.waitpid` waits indefinitely. 

I figured the easiest fix is just to read from the pipe while waiting so this patch does that. `Process.waitpid` never gets called without the`Process::WNOHANG` flag and the output gets added to a string while waiting.

[Related Stack Overflow Discussion](http://stackoverflow.com/questions/13829830/ruby-process-spawn-stdout-pipe-buffer-size-limit)
@gissues:{"order":10,"status":"backlog"}
